### PR TITLE
Switch to Fluent::BufferedOutput and TCP+TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,18 @@ Welcome to the Papertrail Fluentd plugin!
 ## Installation
 
 Install this gem when setting up fluentd:
-
 ```ruby
 gem install fluent-plugin-papertrail
 ```
 
 ## Usage
 
-To configure this in fluentd
+This plugin connects to Papertrail log destinations over TCP+TLS. This connection method should be enabled by default in standard Papertrail accounts, see:
+```
+papertrailapp.com > Settings > Log Destinations
+```
+
+To configure this in fluentd:
 ```xml
 <match whatever.*>
   type papertrail
@@ -29,9 +33,9 @@ Use a record transform plugin to populate within the record the following fields
     facility  A valid syslog facility label
     hostname  The source hostname for papertrail logging
 ```
+
 The following snippet sets up the records for Kubernetes and assumes you are using
 the [fluent-plugin-kubernetes_metadata_filter](https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter) plugin which populates the record with useful metadata:
-
 ```yaml
 <filter kubernetes.**>
   type kubernetes_metadata
@@ -48,7 +52,6 @@ the [fluent-plugin-kubernetes_metadata_filter](https://github.com/fabric8io/flue
     message ${record['log']}
   </record>
 </filter>
-
 ```
 
 The default flush interval for Fluent's buffer is set to 1 second. If you want to override this, for example to 60 seconds, you could add an extra config param `flush_interval` to your match stanza:
@@ -60,6 +63,7 @@ The default flush interval for Fluent's buffer is set to 1 second. If you want t
   flush_interval 60
 </match>
 ```
+
 ## Development
 
 We use git, Make and Docker. 
@@ -81,10 +85,10 @@ To release a new version, update the version number in the [GemSpec](fluent-plug
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/solarwinds/fluent-plugin-papertrail.
 
-
 ## License
 
 The gem is available as open source under the terms of the [Apache License](LICENSE).
 
 # Questions/Comments?
+
 Please [open an issue](https://github.com/solarwinds/fluent-plugin-papertrail/issues/new), we'd love to hear from you. As a SolarWinds Innovation Project, this adapter is supported in a best-effort fashion.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Use a record transform plugin to populate within the record the following fields
     hostname  The source hostname for papertrail logging
 ```
 The following snippet sets up the records for Kubernetes and assumes you are using
-the [fluent-plugin-kubernetes_metadata_filter](https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter) plugin which populates the record with usefule metadata :
+the [fluent-plugin-kubernetes_metadata_filter](https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter) plugin which populates the record with useful metadata:
 
 ```yaml
 <filter kubernetes.**>
@@ -50,9 +50,19 @@ the [fluent-plugin-kubernetes_metadata_filter](https://github.com/fabric8io/flue
 </filter>
 
 ```
+
+The default flush interval for Fluent's buffer is set to 1 second. If you want to override this, for example to 60 seconds, you could add an extra config param `flush_interval` to your match stanza:
+```xml
+<match whatever.*>
+  type papertrail
+  papertrail_host <your papertrail hostname>
+  papertrail_port <your papertrail port>
+  flush_interval 60
+</match>
+```
 ## Development
 
-We use git Make and Docker. 
+We use git, Make and Docker. 
 We have a [Dockerfile](Dockerfile.scratch) where we build a scratch image that contains all the dependencies.
 We have a [Makefile](Makefile) to wrap the common functions and make life easier.
 
@@ -63,7 +73,7 @@ We have a [Makefile](Makefile) to wrap the common functions and make life easier
 `make test`
 
 ### Release in [RubyGems](RubyGems.org)
-To release a new version, update the version number in the [GemSpec](fluent-plugin-papertrail.gemspec) and then, run
+To release a new version, update the version number in the [GemSpec](fluent-plugin-papertrail.gemspec) and then, run:
 
 `make release`
 
@@ -74,7 +84,7 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/solarw
 
 ## License
 
-The gem is available as open source under the terms of the [Apache](LICENSE).
+The gem is available as open source under the terms of the [Apache License](LICENSE).
 
 # Questions/Comments?
 Please [open an issue](https://github.com/solarwinds/fluent-plugin-papertrail/issues/new), we'd love to hear from you. As a SolarWinds Innovation Project, this adapter is supported in a best-effort fashion.

--- a/lib/fluent/plugin/out_papertrail.rb
+++ b/lib/fluent/plugin/out_papertrail.rb
@@ -1,30 +1,84 @@
-require 'syslog_protocol'
-require 'fluent/output'
-
 module Fluent
-  class Papertrail < Fluent::Output
-    attr_accessor :socket, :papertrail_host, :papertrail_port
+  class Papertrail < Fluent::BufferedOutput
+    attr_accessor :socket
 
+    # if left empty in fluent config these config_param's will error
+    config_param :papertrail_host, :string
+    config_param :papertrail_port, :integer
+    # overriding default flush_interval (60 sec) from Fluent::BufferedOutput
+    config_param :flush_interval, :time, default: 1
+
+    # register as 'papertrail' fluent plugin
     Fluent::Plugin.register_output('papertrail', self)
+
+    def initialize
+      super
+      require 'syslog_protocol'
+    end
 
     def configure(conf)
       super
-      @papertrail_host = conf["papertrail_host"]
-      @papertrail_port = conf["papertrail_port"]
-      @socket = UDPSocket.new
+      @socket = create_socket(@papertrail_host, @papertrail_port)
     end
 
-    def emit(tag, es, chain)
-      es.each do |time, record|
-        packet = SyslogProtocol::Packet.new
-        packet.hostname = record['hostname']
-        packet.facility = record['facility']
-        packet.severity = record['severity']
-        packet.tag = record['program']
-        packet.content = record['message']
-        @socket.send(packet.assemble, 0, papertrail_host, papertrail_port)
+    def format(tag, time, record)
+      [tag, time, record].to_msgpack
+    end
+
+    def write(chunk)
+      chunk.msgpack_each {|(tag, time, record)|
+        packet = create_packet(tag, time, record)
+        send_to_papertrail(packet)
+      }
+    end
+
+    def create_socket(host, port)
+      log.info "initializing tcp socket for #{host}:#{port}"
+      begin
+        socket = TCPSocket.new(host, port)
+        log.debug "enabling ssl for socket #{host}:#{port}"
+        ssl = OpenSSL::SSL::SSLSocket.new(socket)
+        # close tcp and ssl socket when either fails
+        ssl.sync_close = true
+        # initiate SSL/TLS handshake with server
+        ssl.connect
+      rescue => e
+        log.warn "failed to create tcp socket #{host}:#{port}: #{e}"
+        ssl = nil
       end
-      chain.next
+      ssl
+    end
+
+    def create_packet(tag,time,record)
+      # construct syslog packet from fluent record
+      packet = SyslogProtocol::Packet.new
+      packet.hostname = record['hostname']
+      packet.facility = record['facility']
+      packet.severity = record['severity']
+      packet.tag      = record['program']
+      packet.content  = record['message']
+      packet.time     = time ? Time.at(time) : Time.now
+      packet
+    end
+
+    def send_to_papertrail(packet)
+      # recreate the socket if it's nil -- see below
+      unless @socket
+        @socket = create_socket(@papertrail_host, @papertrail_port)
+      end
+
+      if @socket
+        begin
+          # send it
+          @socket.puts packet.assemble
+        rescue => e
+          log.error "connection error for #{@papertrail_host}:#{@papertrail_port}: #{e}"
+          # socket failed, reset to nil to recreate for the next write
+          @socket = nil
+        end
+      else
+        log.warn "socket is nil -- failed to send: #{packet.assemble}"
+      end
     end
   end
 end

--- a/test/fluent/papertrail_test.rb
+++ b/test/fluent/papertrail_test.rb
@@ -9,78 +9,74 @@ class Fluent::PapertrailTest < Test::Unit::TestCase
       @packets = []
     end
 
-    def send(message, flag, host, port)
-      @packets << {message: message,
-                   flag: flag,
-                   host: host,
-                   port: port}
+    def puts(message)
+      @packets << message
     end
   end
 
   def setup
     Fluent::Test.setup
-    @driver = Fluent::Test::OutputTestDriver.new(Fluent::Papertrail, 'test')
-    @driver.configure(%[
-      type papertrail
-      papertrail_host test.host
-      papertrail_port 123
-      hostname  emit.host
-      ])
+    @driver = Fluent::Test::BufferedOutputTestDriver.new(Fluent::Papertrail, 'test')
+    @mock_host = 'test.host'
+    @mock_port = 123
+    @driver.configure("
+      papertrail_host #{@mock_host}
+      papertrail_port #{@mock_port}
+      ")
     @driver.instance.socket = TestSocket.new
     @default_record = {
-      'message' => 'some_message',
-      'program' => 'someprogram',
-      'severity' => 'warn',
-      'facility' => 'local0',
-      'hostname' => 'some.host.name'
+        'hostname' => 'some.host.name',
+        'facility' => 'local0',
+        'severity' => 'warn',
+        'program' => 'someprogram',
+        'message' => 'some_message'
     }
   end
 
-  def test_defaults_to_a_udp_socket
-    @driver.configure("")
-    assert @driver.instance.socket.is_a? UDPSocket
+  def test_create_socket_defaults_to_ssl_socket
+    # override the test configuration from above to
+    # create a live SSLSocket with papertrailapp.com
+    @driver.configure('
+      papertrail_host logs3.papertrailapp.com
+      papertrail_port 12345
+      ')
+    assert @driver.instance.socket.is_a? OpenSSL::SSL::SSLSocket
   end
 
-  def test_uses_papertrail_config
-    @driver.emit(@default_record)
-    packet = @driver.instance.socket.packets.last
-    assert_equal packet[:host], 'test.host'
-    assert_equal packet[:port], '123'
+  def test_configure_empty_configuration
+    begin
+      @driver.configure('')
+    rescue => e
+      assert e.is_a? Fluent::ConfigError
+    end
   end
 
-  def test_takes_program_from_record
-    @default_record['program'] = 'myprogram'
-    @driver.emit(@default_record)
-    packet = @driver.instance.socket.packets.last
-    assert packet[:message].include? 'some.host.name myprogram:'
+  def test_configure_uses_papertrail_config
+    assert @driver.instance.papertrail_host.eql? @mock_host
+    assert @driver.instance.papertrail_port.eql? @mock_port
   end
 
-  def test_takes_hostname_from_record
-    @default_record['hostname'] = 'my.special.host'
-    @driver.emit(@default_record)
-    packet = @driver.instance.socket.packets.last
-    assert packet[:message].include? 'my.special.host someprogram:'
+  def test_create_packet_without_timestamp
+    packet = @driver.instance.create_packet(nil, nil, @default_record)
+    assert packet.hostname.to_s.eql? @default_record['hostname']
+    assert packet.facility.to_s.eql? '16'
+    assert packet.severity.to_s.eql? '4'
+    assert packet.tag.to_s.eql? @default_record['program']
+    assert packet.content.to_s.eql? @default_record['message']
   end
 
-  def test_takes_severity_from_record
-    @default_record['severity'] = 'debug'
-    @driver.emit(@default_record)
-    packet = @driver.instance.socket.packets.last
-    assert packet[:message].include? '<135>'
+  def test_create_packet_with_timestamp
+    epoch_time     = 550_611_383
+    converted_date = '1987-06-13'
+    packet = @driver.instance.create_packet(nil, epoch_time, @default_record)
+    assert packet.time.to_s.include? converted_date
   end
 
-  def test_takes_facility_from_record
-    @default_record['facility'] = 'cron'
-    @driver.emit(@default_record)
-    packet = @driver.instance.socket.packets.last
-    assert packet[:message].include? '<76>'
-  end
-
-  def test_takes_message_from_record
-    @default_record['message'] = 'My Very Special Message'
-    @driver.emit(@default_record)
-    packet = @driver.instance.socket.packets.last
-    assert packet[:message].include? 'My Very Special Message'
+  def test_send_to_papertrail_with_test_socket
+    snt_packet = @driver.instance.create_packet(nil, nil, @default_record)
+    @driver.instance.send_to_papertrail(snt_packet)
+    rcv_packet = @driver.instance.socket.packets.last
+    assert rcv_packet.eql? snt_packet.assemble
   end
 
 end


### PR DESCRIPTION
We were experiencing packet loss when sending logs at a high volume to Papertrail with this plugin. Based on Papertrail's documentation this was expected with high volume UDP connections. This pull request converts the plugin to be "backpressure aware" through two mechanisms, leveraging Fluent's BufferedOutput plugin as the base and converting our connection method with Papertrail to TCP.

Along the way I've also added:
- built-in TLS encryption for Papertrail connections
- timestamp forwarding from Fluent to Papertrail (if available)
- error logging in case of plugin failure

All tests are passing:
```
-------------------------------------------------------------------------------
6 tests, 11 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-------------------------------------------------------------------------------
```