### PR TITLE
Update RubyGem release process

### DIFF
--- a/Dockerfile.scratch
+++ b/Dockerfile.scratch
@@ -1,5 +1,5 @@
 # vim:set ft=dockerfile:
-FROM ruby:2.3.5-alpine
+FROM ruby:2.3.6-alpine
 
 MAINTAINER Alex Ouzounis <alex.ouzounis@solarwinds.com>
 

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,7 @@
-# Organisation name
-ORG_NAME=solarwinds
-# Repository name
 REPO_NAME=fluent-plugin-papertrail
-
-
-# Scratch Dockerfile
 SCRATCH_CONTAINER_DOCKERFILE=Dockerfile.scratch
-# Scratch Image name
 SCRATCH_IMAGE_NAME=${REPO_NAME}_scratch
-# Scratch Container name
 SCRATCH_CONTAINER_NAME=${REPO_NAME}_scratch
-
 SCRATCH_CONTAINER_DOCKER_OPTS=--rm -v $(PWD):/home -v $(PWD)/vendor/bundle:/usr/local/bundle -w=/home
 
 build-image-scratch:
@@ -23,7 +14,9 @@ test: install
 	docker run ${SCRATCH_CONTAINER_DOCKER_OPTS} --name ${SCRATCH_CONTAINER_NAME} ${SCRATCH_IMAGE_NAME} bundle exec rake test
 
 release: install
-	docker run ${SCRATCH_CONTAINER_DOCKER_OPTS} --name ${SCRATCH_CONTAINER_NAME} ${SCRATCH_IMAGE_NAME} bundle exec rake release
+	rm -rf ${REPO_NAME}-*.gem
+	docker run ${SCRATCH_CONTAINER_DOCKER_OPTS} --name ${SCRATCH_CONTAINER_NAME} ${SCRATCH_IMAGE_NAME} bundle exec gem build ${REPO_NAME}.gemspec
+	docker run -it ${SCRATCH_CONTAINER_DOCKER_OPTS} --name ${SCRATCH_CONTAINER_NAME} ${SCRATCH_IMAGE_NAME} bundle exec gem push ${REPO_NAME}-*.gem
 
 clean:
 	docker rm ${SCRATCH_CONTAINER_NAME}

--- a/fluent-plugin-papertrail.gemspec
+++ b/fluent-plugin-papertrail.gemspec
@@ -4,14 +4,14 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "fluent-plugin-papertrail"
-  spec.version       = "0.1"
-  spec.authors       = ["Jonathan Lozinski", "Alex Ouzounis"]
-  spec.email         = ["jonathan.lozinski@solarwinds.com", "alex.ouzounis@solarwinds.com"]
+  spec.version       = "0.1.1"
+  spec.authors       = ["Jonathan Lozinski", "Alex Ouzounis", "Chris Rust"]
+  spec.email         = ["jonathan.lozinski@solarwinds.com", "alex.ouzounis@solarwinds.com", "chris.rust@solarwinds.com"]
 
   spec.summary       = %q{Remote Syslog Output Fluentd plugin for papertrail}
   spec.description   = %q{Remote Syslog Output Fluentd plugin for papertrail}
   spec.homepage      = "https://github.com/solarwinds/fluent-plugin-papertrail"
-  spec.license       = "Apache"
+  spec.license       = "Apache-2.0"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.


### PR DESCRIPTION
The `rake release` command wants to make changes to git that don't match our workflow. I've altered that to use `gem build` / `gem push` instead.

I've also incremented and released the RubyGem version.