### PR TITLE
Make Docker image usable for Loggly as well

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,8 @@ RUN echo 'gem: --no-document' >> /etc/gemrc \
     && gem install fluent-plugin-systemd -v 0.3.1 \
     && gem install fluent-plugin-rewrite-tag-filter -v 1.6.0 \
     && gem install fluent-plugin-papertrail -v 0.2.3 \
+    && gem install fluent-plugin-loggly-anno \
+    && gem install fluent-plugin-kubernetes_metadata_input \
     && gem install fluent-plugin-kubernetes_metadata_filter
 
 RUN SUDO_FORCE_REMOVE=yes \

--- a/docker/conf/kubernetes.conf
+++ b/docker/conf/kubernetes.conf
@@ -141,7 +141,7 @@
 <filter kubernetes.**>
   type kubernetes_metadata
   include_namespace_metadata true
-  annotation_match ["solarwinds.io/papertrail_*"]
+  annotation_match ["solarwinds.io/*"]
 </filter>
 
 <filter kube-apiserver-audit>
@@ -168,4 +168,5 @@
     facility local0
     message ${record['log']}
   </record>
+  remove_keys ["log"]
 </filter>


### PR DESCRIPTION
- Add more gems to Docker image for versatility as generic SolarWinds logging image
- Make annotations support more flexible
- Remove duplicated `log` record