### PR TITLE
Fluent 1.0 config compliance

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,11 +12,11 @@ RUN apt-get update \
 
 RUN echo 'gem: --no-document' >> /etc/gemrc \
     && gem install fluent-plugin-systemd -v 0.3.1 \
-    && gem install fluent-plugin-rewrite-tag-filter -v 1.6.0 \
+    && gem install fluent-plugin-rewrite-tag-filter -v 2.0.2 \
     && gem install fluent-plugin-papertrail -v 0.2.3 \
-    && gem install fluent-plugin-loggly-anno \
-    && gem install fluent-plugin-kubernetes_metadata_input \
-    && gem install fluent-plugin-kubernetes_metadata_filter
+    && gem install fluent-plugin-loggly-anno -v 0.0.2 \
+    && gem install fluent-plugin-kubernetes_metadata_input -v 0.21.11 \
+    && gem install fluent-plugin-kubernetes_metadata_filter -v 2.0.0
 
 RUN SUDO_FORCE_REMOVE=yes \
     apt-get purge -y --auto-remove \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update \
 
 RUN echo 'gem: --no-document' >> /etc/gemrc \
     && gem install fluent-plugin-systemd -v 0.3.1 \
-    && gem install fluent-plugin-rewrite-tag-filter -v 2.0.2 \
     && gem install fluent-plugin-papertrail -v 0.2.4 \
     && gem install fluent-plugin-loggly-anno -v 0.0.2 \
     && gem install fluent-plugin-kubernetes_metadata_input -v 0.21.11 \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,8 @@ RUN echo 'gem: --no-document' >> /etc/gemrc \
     && gem install fluent-plugin-systemd -v 0.3.1 \
     && gem install fluent-plugin-rewrite-tag-filter -v 1.6.0 \
     && gem install fluent-plugin-papertrail -v 0.2.3 \
+    && gem install fluent-plugin-loggly-anno \
+    && gem install fluent-plugin-kubernetes_metadata_input \
     && gem install fluent-plugin-kubernetes_metadata_filter
 
 RUN SUDO_FORCE_REMOVE=yes \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update \
 RUN echo 'gem: --no-document' >> /etc/gemrc \
     && gem install fluent-plugin-systemd -v 0.3.1 \
     && gem install fluent-plugin-rewrite-tag-filter -v 2.0.2 \
-    && gem install fluent-plugin-papertrail -v 0.2.3 \
+    && gem install fluent-plugin-papertrail -v 0.2.4 \
     && gem install fluent-plugin-loggly-anno -v 0.0.2 \
     && gem install fluent-plugin-kubernetes_metadata_input -v 0.21.11 \
     && gem install fluent-plugin-kubernetes_metadata_filter -v 2.0.0

--- a/docker/conf/fluent.conf
+++ b/docker/conf/fluent.conf
@@ -3,14 +3,14 @@
 
 ## Capture audit logs
 #<match kube-apiserver-audit>
-#  type papertrail
+#  @type papertrail
 #
 #  papertrail_host "#{ENV['FLUENT_PAPERTRAIL_AUDIT_HOST']}"
 #  papertrail_port "#{ENV['FLUENT_PAPERTRAIL_AUDIT_PORT']}"
 #</match>
 
 <match **>
-  type papertrail
+  @type papertrail
 
   papertrail_host "#{ENV['FLUENT_PAPERTRAIL_HOST']}"
   papertrail_port "#{ENV['FLUENT_PAPERTRAIL_PORT']}"

--- a/docker/conf/kubernetes.conf
+++ b/docker/conf/kubernetes.conf
@@ -1,9 +1,9 @@
 <match fluent.**>
-  type null
+  @type null
 </match>
 
 <source>
-  type tail
+  @type tail
   path /var/log/containers/*.log
   pos_file /var/log/fluentd-containers.log.pos
   time_format %Y-%m-%dT%H:%M:%S.%NZ
@@ -13,7 +13,7 @@
 </source>
 
 <source>
-  type tail
+  @type tail
   format /^(?<time>[^ ]* [^ ,]*)[^\[]*\[[^\]]*\]\[(?<severity>[^ \]]*) *\] (?<message>.*)$/
   time_format %Y-%m-%d %H:%M:%S
   path /var/log/salt/minion
@@ -22,7 +22,7 @@
 </source>
 
 <source>
-  type tail
+  @type tail
   format syslog
   path /var/log/startupscript.log
   pos_file /var/log/fluentd-startupscript.log.pos
@@ -30,7 +30,7 @@
 </source>
 
 <source>
-  type tail
+  @type tail
   format /^time="(?<time>[^)]*)" level=(?<severity>[^ ]*) msg="(?<message>[^"]*)"( err="(?<error>[^"]*)")?( statusCode=($<status_code>\d+))?/
   path /var/log/docker.log
   pos_file /var/log/fluentd-docker.log.pos
@@ -38,7 +38,7 @@
 </source>
 
 <source>
-  type tail
+  @type tail
   format none
   path /var/log/etcd.log
   pos_file /var/log/fluentd-etcd.log.pos
@@ -46,7 +46,7 @@
 </source>
 
 <source>
-  type tail
+  @type tail
   format kubernetes
   multiline_flush_interval 5s
   path /var/log/kubelet.log
@@ -55,7 +55,7 @@
 </source>
 
 <source>
-  type tail
+  @type tail
   format kubernetes
   multiline_flush_interval 5s
   path /var/log/kube-proxy.log
@@ -64,7 +64,7 @@
 </source>
 
 <source>
-  type tail
+  @type tail
   format kubernetes
   multiline_flush_interval 5s
   path /var/log/kube-apiserver.log
@@ -73,7 +73,7 @@
 </source>
 
 <source>
-  type tail
+  @type tail
   format kubernetes
   multiline_flush_interval 5s
   path /var/log/kube-controller-manager.log
@@ -82,7 +82,7 @@
 </source>
 
 <source>
-  type tail
+  @type tail
   format kubernetes
   multiline_flush_interval 5s
   path /var/log/kube-scheduler.log
@@ -91,7 +91,7 @@
 </source>
 
 <source>
-  type tail
+  @type tail
   format kubernetes
   multiline_flush_interval 5s
   path /var/log/rescheduler.log
@@ -100,7 +100,7 @@
 </source>
 
 <source>
-  type tail
+  @type tail
   format kubernetes
   multiline_flush_interval 5s
   path /var/log/glbc.log
@@ -109,7 +109,7 @@
 </source>
 
 <source>
-  type tail
+  @type tail
   format kubernetes
   multiline_flush_interval 5s
   path /var/log/cluster-autoscaler.log
@@ -121,7 +121,7 @@
 # 2017-02-09T00:15:57.992775796Z AUDIT: id="90c73c7c-97d6-4b65-9461-f94606ff825f" ip="104.132.1.72" method="GET" user="kubecfg" as="<self>" asgroups="<lookup>" namespace="default" uri="/api/v1/namespaces/default/pods"
 # 2017-02-09T00:15:57.993528822Z AUDIT: id="90c73c7c-97d6-4b65-9461-f94606ff825f" response="200"
 <source>
-  type tail
+  @type tail
   format multiline
   multiline_flush_interval 5s
   format_firstline /^\S+\s+AUDIT:/
@@ -139,13 +139,12 @@
 </source>
 
 <filter kubernetes.**>
-  type kubernetes_metadata
-  include_namespace_metadata true
+  @type kubernetes_metadata
   annotation_match ["solarwinds.io/*"]
 </filter>
 
 <filter kube-apiserver-audit>
-  type record_transformer
+  @type record_transformer
   enable_ruby true
   <record>
     hostname #{ENV['FLUENT_HOSTNAME']}
@@ -159,7 +158,7 @@
 # append namespace and pod name to hostname, so that logs in Papertrail are filterable by each
 # use container name as program name, but trim it to 32 characters to match remote_syslog spec
 <filter kubernetes.**>
-  type record_transformer
+  @type record_transformer
   enable_ruby true
   <record>
     hostname #{ENV['FLUENT_HOSTNAME']}-${record["kubernetes"]["namespace_name"]}-${record["kubernetes"]["pod_name"]}

--- a/docker/conf/kubernetes.conf
+++ b/docker/conf/kubernetes.conf
@@ -141,7 +141,7 @@
 <filter kubernetes.**>
   type kubernetes_metadata
   include_namespace_metadata true
-  annotation_match ["solarwinds.io/papertrail_*"]
+  annotation_match ["solarwinds.io/*"]
 </filter>
 
 <filter kube-apiserver-audit>
@@ -168,4 +168,5 @@
     facility local0
     message ${record['log']}
   </record>
+  remove_keys ["log"]
 </filter>

--- a/docker/conf/systemd.conf
+++ b/docker/conf/systemd.conf
@@ -1,16 +1,27 @@
 <source>
   @type systemd
-  pos_file /var/log/fluentd-journald-systemd.pos
-  read_from_head true
-  strip_underscores true
   tag systemd
+  read_from_head true
+  <storage>
+    @type local
+    persistent true
+    path /var/log/fluentd-journald-systemd.pos
+  </storage>
 </source>
 
 # rewrite tags as systemd.* for the specefic SYSTEMD_UNIT, then we can filter specifically on kubelet and docker below
 <match systemd>
   @type rewrite_tag_filter
-  rewriterule1 SYSTEMD_UNIT   ^kubelet.service$  systemd.kubelet
-  rewriterule2 SYSTEMD_UNIT   ^docker.service$   systemd.docker
+  <rule>
+    key SYSTEMD_UNIT
+    pattern /^kubelet.service$/
+    tag systemd.kubelet
+  </rule>
+  <rule>
+    key SYSTEMD_UNIT
+    pattern /^docker.service$/
+    tag systemd.docker
+  </rule>
 </match>
 
 # toss all other systemd logs in the bin
@@ -32,11 +43,10 @@
 </filter>
 
 <filter systemd.docker>
-  type parser
+  @type parser
   format /^time="(?<time>[^)]*)" level=(?<severity>[^ ]*) msg="(?<message>[^"]*)"( err="(?<error>[^"]*)")?( statusCode=($<status_code>\d+))?/
   reserve_data true
   key_name MESSAGE
-  suppress_parse_error_log true
 </filter>
 
 <filter systemd.docker>

--- a/docker/conf/systemd.conf
+++ b/docker/conf/systemd.conf
@@ -1,40 +1,25 @@
 <source>
   @type systemd
-  tag systemd
+  tag systemd.kubelet
+  filters [{ "_SYSTEMD_UNIT": "kubelet.service" }]
+  pos_file /var/log/fluentd-systemd-kubelet.pos
   read_from_head true
-  <storage>
-    @type local
-    persistent true
-    path /var/log/fluentd-journald-systemd.pos
-  </storage>
 </source>
 
-# rewrite tags as systemd.* for the specefic SYSTEMD_UNIT, then we can filter specifically on kubelet and docker below
-<match systemd>
-  @type rewrite_tag_filter
-  <rule>
-    key SYSTEMD_UNIT
-    pattern /^kubelet.service$/
-    tag systemd.kubelet
-  </rule>
-  <rule>
-    key SYSTEMD_UNIT
-    pattern /^docker.service$/
-    tag systemd.docker
-  </rule>
-</match>
-
-# toss all other systemd logs in the bin
-<match systemd>
-  @type null
-</match>
+<source>
+  @type systemd
+  tag systemd.docker
+  filters [{ "_SYSTEMD_UNIT": "docker.service" }]
+  pos_file /var/log/fluentd-systemd-docker.pos
+  read_from_head true
+</source>
 
 # transform systemd logs to Papertrail format
 <filter systemd.kubelet>
   @type record_transformer
   enable_ruby true
   <record>
-    hostname "#{ENV['FLUENT_HOSTNAME']}-${record['HOSTNAME']}"
+    hostname "#{ENV['FLUENT_HOSTNAME']}-#{ENV['K8S_NODE_NAME']}"
     program kubelet
     severity info
     facility local0
@@ -53,7 +38,7 @@
   @type record_transformer
   enable_ruby true
   <record>
-    hostname "#{ENV['FLUENT_HOSTNAME']}-${record['HOSTNAME']}"
+    hostname "#{ENV['FLUENT_HOSTNAME']}-#{ENV['K8S_NODE_NAME']}"
     program docker
     severity info
     facility local0

--- a/fluent-plugin-papertrail.gemspec
+++ b/fluent-plugin-papertrail.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "fluent-plugin-papertrail"
-  spec.version       = "0.2.3"
+  spec.version       = "0.2.4"
   spec.authors       = ["Jonathan Lozinski", "Alex Ouzounis", "Chris Rust"]
   spec.email         = ["jonathan.lozinski@solarwinds.com", "alex.ouzounis@solarwinds.com", "chris.rust@solarwinds.com"]
 

--- a/kubernetes/fluentd-daemonset-papertrail.yaml
+++ b/kubernetes/fluentd-daemonset-papertrail.yaml
@@ -22,7 +22,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: fluentd
-        image: quay.io/solarwinds/fluentd-kubernetes:v1.1.1-debian-papertrail-0.2.3
+        image: quay.io/solarwinds/fluentd-kubernetes:v1.1.1-debian-papertrail-0.2.4
         imagePullPolicy: Always
         env:
           - name: FLUENT_PAPERTRAIL_HOST

--- a/kubernetes/fluentd-daemonset-papertrail.yaml
+++ b/kubernetes/fluentd-daemonset-papertrail.yaml
@@ -31,6 +31,10 @@ spec:
             value: 'NNNNN'
           - name: FLUENT_HOSTNAME
             value: 'my-cluster-name'
+          - name: K8S_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
         resources:
           limits:
             cpu: 200m


### PR DESCRIPTION
- Update and pin fluent plugin versions to latest
- Update Kubernetes example configs to be fluent 1.0 compliant
- Retool config to remove rewrite-tag-filter plugin
- Pass K8S_NODE_NAME to kubernetes metadata filter to reduce cache misses and needless calls to the api