### PR TITLE
Use a larger default syslog pkt size

### DIFF
--- a/lib/fluent/plugin/out_papertrail.rb
+++ b/lib/fluent/plugin/out_papertrail.rb
@@ -13,6 +13,7 @@ module Fluent
     # overriding default flush_interval (60 sec) from Fluent::BufferedOutput
     config_param :flush_interval, :time, default: 1
     config_param :discard_unannotated_pod_logs, :bool, default: false
+    config_param :maximum_syslog_packet_size, :integer, default: 99990
 
     # register as 'papertrail' fluent plugin
     Fluent::Plugin.register_output('papertrail', self)
@@ -115,7 +116,7 @@ module Fluent
       else
         begin
           # send it
-          @sockets[socket_key].puts packet.assemble
+          @sockets[socket_key].puts packet.assemble(max_size=@maximum_syslog_packet_size)
         rescue => e
           err_msg = "Error writing to #{socket_key}: #{e}"
           # socket failed, reset to nil to recreate for the next write


### PR DESCRIPTION
This changes adds a parameter that allows the user to set the maximum size of a syslog packet created by this plugin. It sets a default of 99990 bytes which is the same as the default value used by remote_syslog2. Since this plugin is intended to interface only with Papertrail we can safely increase this limit to that value.

Related to issue #17 .