### PR TITLE
Discard nil destination logs

### DIFF
--- a/fluent-plugin-papertrail.gemspec
+++ b/fluent-plugin-papertrail.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "fluent-plugin-papertrail"
-  spec.version       = "0.2.6"
+  spec.version       = "0.2.7"
   spec.authors       = ["Jonathan Lozinski", "Alex Ouzounis", "Chris Rust"]
   spec.email         = ["jonathan.lozinski@solarwinds.com", "alex.ouzounis@solarwinds.com", "chris.rust@solarwinds.com"]
 

--- a/lib/fluent/plugin/out_papertrail.rb
+++ b/lib/fluent/plugin/out_papertrail.rb
@@ -106,7 +106,21 @@ module Fluent
         host = @papertrail_host
         port = @papertrail_port
       end
-      form_socket_key(host, port)
+      socket_key = form_socket_key(host, port)
+
+      if socket_key == ':'
+        kubernetes_err_msg = ''
+        if record.dig('kubernetes', 'namespace_name')
+          namespace_name = record['kubernetes']['namespace_name']
+          kubernetes_err_msg = " from Kubernetes namespace: \"#{namespace_name}\""
+        end
+        log.warn("Received nil socket_configuration#{kubernetes_err_msg}. Discarding message.")
+        host = DISCARD_STRING
+        port = DISCARD_STRING
+        socket_key = form_socket_key(host, port)
+      end
+
+      socket_key
     end
 
     def send_to_papertrail(packet, socket_key)

--- a/test/fluent/papertrail_test.rb
+++ b/test/fluent/papertrail_test.rb
@@ -144,5 +144,45 @@ class Fluent::PapertrailTest < Test::Unit::TestCase
     @driver.instance.pick_socket(pod_annotation_record)
     @driver.instance.sockets[pod_socket_key] ||= @driver.instance.create_socket(pod_socket_key)
     assert true.eql? @driver.instance.sockets.key?(pod_socket_key)
+
+    nil_host = ''
+    nil_port = ''
+    nil_socket_key = "DISCARD:DISCARD"
+
+    nil_namespace_annotation_record = {
+        'hostname' => 'some_hostname',
+        'facility' => 'local0',
+        'severity' => 'warn',
+        'program' => 'some_program',
+        'message' => 'some_message',
+        'kubernetes' => {
+          'namespace_annotations' => {
+            'solarwinds_io/papertrail_host' => nil_host,
+            'solarwinds_io/papertrail_port' => nil_port
+          }
+        }
+    }
+
+    picked_socket_key = @driver.instance.pick_socket(nil_namespace_annotation_record)
+    # in this case @driver.instance.sockets is never actually configured, so we assert against picked name instead
+    assert picked_socket_key.eql? nil_socket_key
+
+    nil_pod_annotation_record = {
+        'hostname' => 'some_hostname',
+        'facility' => 'local0',
+        'severity' => 'warn',
+        'program' => 'some_program',
+        'message' => 'some_message',
+        'kubernetes' => {
+          'annotations' => {
+            'solarwinds_io/papertrail_host' => nil_host,
+            'solarwinds_io/papertrail_port' => nil_port
+          }
+        }
+    }
+
+    picked_socket_key = @driver.instance.pick_socket(nil_pod_annotation_record)
+    # in this case @driver.instance.sockets is never actually configured, so we assert against picked name instead
+    assert picked_socket_key.eql? nil_socket_key
   end
 end


### PR DESCRIPTION
We were getting the following errors from misannotated user namespaces:
```
2019-01-25 17:03:23 +0000 [info]: #0 initializing tcp socket for : 
2019-01-25 17:03:23 +0000 [warn]: #0 failed to create tcp socket :: getaddrinfo: Name or service not known 
2019-01-25 17:03:23 +0000 [warn]: #0 failed to flush the buffer. retry_time=0 next_retry_seconds=2019-01-25 17:03:24 +0000 chunk="57f91e73215e8250a167762d7e008661" error_class=Fluent::Papertrail::SocketFailureError error="Unable to create socket with :"
```
Throw these logs out (to avoid ballooning the buffer and/or locking up the process) and log the culprit for future analysis.